### PR TITLE
Support for other mal implementations

### DIFF
--- a/mal-interpreter/ruby/core.rb
+++ b/mal-interpreter/ruby/core.rb
@@ -8,6 +8,7 @@ $core_ns = {
     :nil? =>      lambda {|a| a == nil},
     :true? =>     lambda {|a| a == true},
     :false? =>    lambda {|a| a == false},
+    :string? =>   lambda {|a| (a.is_a? String) && "\u029e" != a[0]},
     :symbol =>    lambda {|a| a.to_sym},
     :symbol? =>   lambda {|a| a.is_a? Symbol},
     :keyword =>   lambda {|a| "\u029e"+a},
@@ -51,9 +52,11 @@ $core_ns = {
     :rest =>      lambda {|a| List.new(a.nil? || a.size == 0 ? [] : a.drop(1))},
     :empty? =>    lambda {|a| a.size == 0},
     :count =>     lambda {|a| return 0 if a == nil; a.size},
-    :conj =>      lambda {|*a| a[0].clone.conj(a.drop(1))},
     :apply =>     lambda {|*a| a[0][*a[1..-2].concat(a[-1])]},
     :map =>       lambda {|a,b| List.new(b.map {|e| a[e]})},
+
+    :conj =>      lambda {|*a| a[0].clone.conj(a.drop(1))},
+    :seq =>       lambda {|a| a.nil? ? nil : a.size == 0 ? nil : a.seq},
 
     :"with-meta" => lambda {|a,b| x = a.clone; x.meta = b; x},
     :meta =>      lambda {|a| a.meta},

--- a/mal-interpreter/ruby/types.rb
+++ b/mal-interpreter/ruby/types.rb
@@ -7,10 +7,19 @@ class MalException < StandardError
   end
 end
 
+class String # re-open and add seq
+    def seq()
+        return List.new self.split("")
+    end
+end
+
 class List < Array
     attr_accessor :meta
     def conj(xs)
         xs.each{|x| self.unshift(x)}
+        return self
+    end
+    def seq()
         return self
     end
 end
@@ -20,6 +29,9 @@ class Vector < Array
     def conj(xs)
         self.push(*xs)
         return self
+    end
+    def seq()
+        return List.new self
     end
 end
 

--- a/malc
+++ b/malc
@@ -6,20 +6,32 @@ if [ -z "$1" ] ; then
   exit 1
 fi
 
-bindir=$(dirname $0)
+bindir=$(readlink -f $(dirname $0))
+
+# user overridable
+MAL_PREFIX=${MAL_PREFIX:-}
+MAL_IMPL=$(readlink -f ${MAL_IMPL:-$bindir/mal-interpreter/mal})
+
+rundir=$(dirname ${MAL_IMPL})
+
 leave_llvm=no
 if [ "$1" = "-l" ] ; then
   leave_llvm=yes
   shift
 fi
-srcfile=$1
+srcfile="$(readlink -f $1)"
 if [ -n "$2" ] ; then
-  out="$2"
+  out="$(readlink -f $2)"
 else
   out="$(dirname $srcfile)/$(basename $srcfile .mal)"
 fi
 
-$bindir/mal-interpreter/mal $bindir/malc.mal $bindir $srcfile > $out.ll
+if [ -n "$rundir" ]; then
+    cd "$rundir"
+fi
+
+cd ${rundir}
+${MAL_PREFIX:+${MAL_PREFIX} }${MAL_IMPL} $bindir/malc.mal $bindir $srcfile > $out.ll
 opt -S -O3 $out.ll -o $out.opt.ll
 llc -filetype=obj $out.opt.ll -o $out.o
 gcc $out.o -lgc -lreadline -o $out

--- a/utils.mal
+++ b/utils.mal
@@ -22,7 +22,8 @@
       (iter "" seq))))
 
 (def! string/length
-  (rb* "lambda { |s| s.size }"))
+  (fn* [s]
+    (count (seq (str s)))))
 
 (def! string?
   (fn* [o]


### PR DESCRIPTION
This requires https://github.com/kanaka/mal/issues/166 to be completed (seq/string?) for each implementation to work. Also, there are some other issues in _malc.mal_ itself that break some implementations. For example, _malc.mal_ uses symbols for hash-map keys, but only keywords and strings are required for mal implementations (some happen to support symbol keys).
